### PR TITLE
Cache the entry points discovered within a namespace

### DIFF
--- a/stevedore/extension.py
+++ b/stevedore/extension.py
@@ -56,9 +56,17 @@ class ExtensionManager(object):
                                              invoke_args,
                                              invoke_kwds)
 
+    ENTRY_POINT_CACHE = {}
+
+    def _find_entry_points(self, namespace):
+        if namespace not in self.ENTRY_POINT_CACHE:
+            eps = list(pkg_resources.iter_entry_points(namespace))
+            self.ENTRY_POINT_CACHE[namespace] = eps
+        return self.ENTRY_POINT_CACHE[namespace]
+
     def _load_plugins(self, invoke_on_load, invoke_args, invoke_kwds):
         extensions = []
-        for ep in pkg_resources.iter_entry_points(self.namespace):
+        for ep in self._find_entry_points(self.namespace):
             LOG.debug('found extension %r', ep)
             try:
                 ext = self._load_one_plugin(ep,


### PR DESCRIPTION
Scanning the entry point registry is relatively expensive
and causes performance issues with unit tests of code
depending on stevedore. This change addresses the
performance issues by caching the entry points as
they are loaded from pkg_resources in a class attribute
in the base class of the extension managesr so they can
be reused by other instances.

Change-Id: Iba7bee6790cdedc94cb537e2ed6e12219c85f26a
Signed-off-by: Doug Hellmann doug.hellmann@dreamhost.com
