### PR TITLE
NamedExtensionManager can optionally order loaded extensions to match the names parameter.

### DIFF
--- a/stevedore/named.py
+++ b/stevedore/named.py
@@ -4,7 +4,7 @@ from .extension import ExtensionManager
 class NamedExtensionManager(ExtensionManager):
     """Loads only the named extensions.
 
-    This is useful for explictly enabling extensions in a
+    This is useful for explicitly enabling extensions in a
     configuration file, for example.
 
     :param namespace: The namespace for the entry points.
@@ -22,10 +22,14 @@ class NamedExtensionManager(ExtensionManager):
         the object returned by the entry point. Only used if invoke_on_load
         is True.
     :type invoke_kwds: dict
+    :param name_order: If true, sort the loaded extensions to match the
+        order used in ``names``.
+    :type name_order: bool
     """
 
     def __init__(self, namespace, names,
-                 invoke_on_load=False, invoke_args=(), invoke_kwds={}):
+                 invoke_on_load=False, invoke_args=(), invoke_kwds={},
+                 name_order=False):
         self._names = names
         super(NamedExtensionManager, self).__init__(
             namespace,
@@ -33,6 +37,9 @@ class NamedExtensionManager(ExtensionManager):
             invoke_args=invoke_args,
             invoke_kwds=invoke_kwds,
         )
+
+        if name_order:
+            self.extensions.sort(key=lambda x: names.index(x.name))
 
     def _load_one_plugin(self, ep, invoke_on_load, invoke_args, invoke_kwds):
         # Check the name before going any further to prevent

--- a/stevedore/tests/test_named.py
+++ b/stevedore/tests/test_named.py
@@ -35,3 +35,24 @@ def test_enabled_before_load():
         )
         actual = em.names()
         assert actual == []
+
+
+def test_extensions_listed_in_name_order():
+    # Since we don't know the "natural" order of the extensions, run
+    # the test both ways: if the sorting is broken, one of them will
+    # fail
+    em = named.NamedExtensionManager(
+        'stevedore.test.extension',
+        names='t1 t2',
+        name_order=True
+    )
+    actual = em.names()
+    assert actual == ['t1', 't2']
+
+    em = named.NamedExtensionManager(
+        'stevedore.test.extension',
+        names='t2 t1',
+        name_order=True
+    )
+    actual = em.names()
+    assert actual == ['t2', 't1']


### PR DESCRIPTION
Entry point load order is effectively indeterminate, yet an application may want to impose an ordering on loaded extensions. This small change allows NamedExtensionManager creators to optionally indicate that the order of the names listed in the names parameter is significant.
