### PR TITLE
Adds a variant of the map function which allows propogation of exceptions

### DIFF
--- a/stevedore/tests/test_extension.py
+++ b/stevedore/tests/test_extension.py
@@ -126,6 +126,22 @@ def test_map_eats_errors():
     assert results == []
 
 
+def test_map_propagate_exceptions():
+
+    def mapped(ext, *args, **kwds):
+        raise RuntimeError('hard coded error')
+
+    em = extension.ExtensionManager('stevedore.test.extension',
+                                    invoke_on_load=True,
+                                    )
+
+    try:
+        em.map(mapped, 1, 2, a='A', b='B')
+        assert False
+    except:
+        pass
+
+
 def test_map_errors_when_no_plugins():
 
     def mapped(ext, *args, **kwds):


### PR DESCRIPTION
Adds map_propogate_exceptions function which differs from map
in that it allows the propagation of exceptions from extension
functions rather than just logging and ignoring them

Am not so sure about the function name, but I can't think of anything better and
I don't think its possible to modify map without breaking backwards compatibility.
It is however a feature I really would like for use within Nova as currently there is no
way to propagate errors up gracefully.
