### PR TITLE
Fix doc build with Python 2.6.x

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,8 @@ copyright = u'%s, DreamHost' % datetime.date.today().year
 # built documents.
 #
 # The short X.Y version.
-version = subprocess.check_output(['sh', '-c', 'cd ../..; python setup.py --version'])
+version = subprocess.Popen(['sh', '-c', 'cd ../..; python setup.py --version'],
+                           stdout=subprocess.PIPE).stdout.read()
 version = version.strip()
 # The full version, including alpha/beta/rc tags.
 release = version


### PR DESCRIPTION
subprocess.check_output was new in Python 2.7.
Use an alternative construct via subprocess.Popen
which works on Python 2.6 as well.
