### PR TITLE
Fixed a bug in the test for propagating map exceptions

### DIFF
--- a/stevedore/tests/test_extension.py
+++ b/stevedore/tests/test_extension.py
@@ -139,7 +139,7 @@ def test_map_propagate_exceptions():
     try:
         em.map(mapped, 1, 2, a='A', b='B')
         assert False
-    except:
+    except RuntimeError:
         pass
 
 


### PR DESCRIPTION
A too-broad except clause caused the test to always pass by trapping the assertion error designed to trigger test failure.
