### PR TITLE
Update null log handling for py26

### DIFF
--- a/stevedore/__init__.py
+++ b/stevedore/__init__.py
@@ -1,5 +1,13 @@
 # flake8: noqa
 
+__all__ = [
+    'ExtensionManager',
+    'EnabledExtensionManager',
+    'NamedExtensionManager',
+    'HookManager',
+    'DriverManager',
+]
+
 from .extension import ExtensionManager
 from .enabled import EnabledExtensionManager
 from .named import NamedExtensionManager
@@ -10,9 +18,19 @@ import logging
 
 # Configure a NullHandler for our log messages in case
 # the app we're used from does not set up logging.
-LOG = logging.getLogger(__name__)
-try:
+LOG = logging.getLogger('stevedore')
+
+if hasattr(logging, 'NullHandler'):
     LOG.addHandler(logging.NullHandler())
-except AttributeError:
-    # No NullHandler, probably python 2.6
-    pass
+else:
+    class NullHandler(logging.Handler):
+        def handle(self, record):
+            pass
+
+        def emit(self, record):
+            pass
+
+        def createLock(self):
+            self.lock = None
+
+    LOG.addHandler(NullHandler())


### PR DESCRIPTION
Python 2.6 does not have a NullHandler in the logging
module, so introduce a little class that does the same
work.

Also add **all** to the package init so extra names are
not exported.

Resolves issue #2

Change-Id: Id59d394cd02372e2c31de336894f06653cb1e22d
