### PR TITLE
a work-around to avoid cpython bug (15881)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 import setuptools
 
+# In python < 2.7.4, a lazy loading of package `pbr` will break
+# setuptools if some other modules registered functions in `atexit`.
+# solution from: http://bugs.python.org/issue15881#msg170215
+try:
+    import multiprocessing  # flake8: noqa
+except ImportError:
+    pass
+
 setuptools.setup(
     setup_requires=['pbr>=0.5.21,<1.0'],
     pbr=True)


### PR DESCRIPTION
In python < 2.7.4, a lazy loading of package `pbr` will break setuptools if some other modules registered functions in `atexit`.
solution from: http://bugs.python.org/issue15881#msg170215
