### PR TITLE
Consistent extension ordering

### DIFF
--- a/stevedore/extension.py
+++ b/stevedore/extension.py
@@ -4,6 +4,7 @@
 import pkg_resources
 
 import logging
+import operator
 
 
 LOG = logging.getLogger(__name__)
@@ -140,6 +141,7 @@ class ExtensionManager(object):
             except Exception as err:
                 LOG.error('Could not load %r: %s', ep.name, err)
                 LOG.exception(err)
+        extensions.sort(key=operator.attrgetter('name'))
         return extensions
 
     def _load_one_plugin(self, ep, invoke_on_load, invoke_args, invoke_kwds):

--- a/stevedore/tests/test_extension.py
+++ b/stevedore/tests/test_extension.py
@@ -167,3 +167,24 @@ def test_map_method():
 
     result = em.map_method('get_args_and_data', 42)
     assert set(r[2] for r in result) == set([42])
+
+
+def test_ordered_extensions():
+    em = extension.ExtensionManager("stevedore.test.extension.ordering")
+    fake_entry_points = mock.MagicMock()
+
+    names = ['zoo', 'blah', 'foo']
+    fake_entry_points.side_effect = names
+    plugins = [mock.MagicMock() for x in names]
+    for name, plugin in zip(names, plugins):
+        plugin.name = name
+
+    fake_plugins = mock.MagicMock()
+    fake_plugins.side_effect = plugins
+
+    with mock.patch.object(em, '_find_entry_points', fake_entry_points):
+        with mock.patch.object(em, '_load_one_plugin', fake_plugins):
+            ext = em._load_plugins(None, None, None)
+            names.sort()
+            ex_names = [e.name for e in ext]
+            assert names == ex_names


### PR DESCRIPTION
Extensions are now always stored in order (by name). Entry points may
be found in any order which can break tests. This patch keeps
extensions in a consistent order between runs.

Fixes issue #34
