### PR TITLE
Add docs/Makefile to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include setup.py
-recursive-include docs *.rst *.py *.html *.css *.js *.png *.txt *.jpg
+recursive-include docs Makefile *.rst *.py *.html *.css *.js *.png *.txt *.jpg
 recursive-include tests *.py
 include tox.ini
 include LICENSE


### PR DESCRIPTION
When building the documentation for packaging, I found that the
documentation was present but missing its Makefile.  This just adds the
Makefile to the MANIFEST.